### PR TITLE
Switch to Minima's built-in social icons

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -22,26 +22,7 @@
       </div>
 
       <div class="footer-col footer-col-2">
-        {%- if site.minima.social_links -%}
-          <ul class="social-links">
-            {%- for entry in site.minima.social_links -%}
-              {%- assign platform = entry[0] -%}
-              {%- assign username = entry[1] -%}
-              {%- assign url = username -%}
-              {%- if platform == 'github' -%}
-                {%- assign url = 'https://github.com/' | append: username -%}
-                <li><a href="{{ url }}" rel="me"><i class="fab fa-github"></i></a></li>
-              {%- elsif platform == 'linkedin' -%}
-                {%- assign url = 'https://www.linkedin.com/in/' | append: username -%}
-                <li><a href="{{ url }}" rel="me"><i class="fab fa-linkedin"></i></a></li>
-              {%- elsif platform == 'resume' -%}
-                <li><a href="{{ url }}"><i class="fas fa-file"></i></a></li>
-              {%- else -%}
-                <li><a href="{{ url }}">{{ platform }}</a></li>
-              {%- endif -%}
-            {%- endfor -%}
-          </ul>
-        {%- endif -%}
+        {%- include social.html -%}
       </div>
 
       <div class="footer-col footer-col-3">

--- a/_includes/social.html
+++ b/_includes/social.html
@@ -1,0 +1,26 @@
+<ul class="social-media-list">
+  {%- for entry in site.minima.social_links -%}
+    {%- assign platform = entry[0] -%}
+    {%- assign username = entry[1] -%}
+    {%- assign url = username -%}
+    {%- if platform == 'github' -%}
+      {%- assign url = 'https://github.com/' | append: username -%}
+    {%- elsif platform == 'linkedin' -%}
+      {%- assign url = 'https://www.linkedin.com/in/' | append: username -%}
+    {%- endif -%}
+    <li>
+      <a href="{{ url }}" rel="me">
+        {%- case platform -%}
+          {%- when 'github' -%}
+            <svg class="svg-icon"><use xlink:href="{{ '/assets/minima-social-icons.svg#github' | relative_url }}"></use></svg>
+          {%- when 'linkedin' -%}
+            <svg class="svg-icon"><use xlink:href="{{ '/assets/minima-social-icons.svg#linkedin' | relative_url }}"></use></svg>
+          {%- when 'rss' -%}
+            <svg class="svg-icon"><use xlink:href="{{ '/assets/minima-social-icons.svg#rss' | relative_url }}"></use></svg>
+          {%- else -%}
+            {{ platform }}
+        {%- endcase -%}
+      </a>
+    </li>
+  {%- endfor -%}
+</ul>

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -1,8 +1,5 @@
 /* Custom main stylesheet for the site
-   - loads Font Awesome from CDN for icon classes used in _config.yml
    - imports Minima's default styles
 */
-
-@import url('https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css');
 
 @import "minima";


### PR DESCRIPTION
## Summary
- replace custom Font Awesome footer icons with Minima's built-in SVGs
- remove Font Awesome stylesheet import
- provide social links include that uses `minima.social_links`

## Testing
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_68ad0a888ad8833084fa2cc7ec63f04d